### PR TITLE
make all the test green

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/binary"
 	"io/ioutil"
 	"math/rand"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,7 +71,7 @@ func checkValuePanics(t *testing.T, itr Iterator) {
 func newTempDB(t *testing.T, backend BackendType) (db DB, dbDir string) {
 	dirname, err := ioutil.TempDir("", "db_common_test")
 	require.NoError(t, err)
-	db, err = NewDB("testdb", backend, dirname)
+	db, err = NewDB("testdb"+strconv.Itoa(time.Now().Nanosecond()), backend, dirname)
 	require.NoError(t, err)
 	return db, dirname
 }


### PR DESCRIPTION
I found a solution, all 35 jobs passed, as you can see here: https://github.com/mhughdo/tm-db/actions/runs/2754454832. 

- The reason for "panic: close of closed channel [recovered]" error is because when you run `go test -count 5000 -tags pebbledb -test.run ^TestDBIterator/pebbledb$`, thousands of tests are gonna use the same DB file. Some tests finish and close/remove the file, right after that, some other tests might also do the same which will cause panic. Simply use a random file name each time a test runs and you'll be fine
- For the `panic: test timed out after 10m0s` you can just simply add the timeout flag to the command, something like this: `go test  -timeout 20m -count 5000 -tags pebbledb -test.run ^TestDBIterator/pebbledb$`